### PR TITLE
Add analytics events

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,12 +2,22 @@
   import page from 'page'
   import userStore from './store/user'
   import cosmos from './services/cosmos'
+  import events from './services/events'
   import MainLayout from './layout/MainLayout'
   import * as pages from './pages'
 
   let component
   let pageParams = {}
   let navAction
+
+  // configure analytics / segment
+  const tracker = events.configure()
+
+  userStore.subscribe(account => {
+    tracker.identify(account.address, {
+      name: account.profile.name,
+    })
+  })
 
   page((ctx, next) => {
     component = null

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 const defaultOptions = {
   leaderboardFrameInterval: 10000,
   dataPollingInterval: 5000,
+  segmentWriteApiKey: '6tAoLDmWqPfUxy30obm1ZqxcTbZ3zom8',
 }
 
 const domains = {

--- a/src/pages/AddContact.svelte
+++ b/src/pages/AddContact.svelte
@@ -1,12 +1,18 @@
 <script>
   import page from 'page'
   import userStore from '../store/user'
+  import events from '../services/events'
   import PageWithAction from '../layout/PageWithAction'
   import { Button, Textarea, Avatar, Attributes } from '../components'
   import cosmos from '../services/cosmos'
   import config from '../config'
 
   export let pageParams
+
+  const tracker = events.configured()
+  tracker.track('view', {
+    category: 'share_contact',
+  })
 
   let isSelf = false
   let contactName = ''
@@ -27,6 +33,10 @@
     await cosmos.scanContact(pageParams.badgeId, sharePayload)
     loadingShare = false
     page('/')
+    tracker.track('click', {
+      category: 'share_contact',
+      label: 'confirm',
+    })
   }
 
   const handleSkip = async () => {
@@ -34,6 +44,10 @@
     await cosmos.scanContact(pageParams.badgeId)
     loadingSkip = false
     page('/')
+    tracker.track('click', {
+      category: 'share_contact',
+      label: 'skip',
+    })
   }
 
   cosmos.getContactByBadge(pageParams.badgeId).then(contact => {

--- a/src/pages/BeginVerification.svelte
+++ b/src/pages/BeginVerification.svelte
@@ -1,2 +1,12 @@
+<script>
+  import events from '../services/events'
+
+  const tracker = events.configured()
+  tracker.track('view', {
+    category: 'login',
+    action: 'check_email',
+  })
+</script>
+
 <h1>Check your email</h1>
 <p>We've sent you an email with a link to log you in!</p>

--- a/src/pages/Home/index.svelte
+++ b/src/pages/Home/index.svelte
@@ -1,10 +1,16 @@
 <script>
   import page from 'page'
   import config from '../../config'
+  import events from '../../services/events'
   import PageWithAction from '../../layout/PageWithAction'
   import { ReputationLog, Button } from '../../components'
   import playerStore from '../../store/player'
   import ScanIcon from './ScanIcon'
+
+  const tracker = events.configured()
+  tracker.track('view', {
+    category: 'home',
+  })
 
   const scanContact = () => page('/scan')
   const openContact = e => {

--- a/src/pages/Intro.svelte
+++ b/src/pages/Intro.svelte
@@ -1,6 +1,13 @@
 <script>
   import page from 'page'
+  import events from '../services/events'
   import { QRScanner } from '../components'
+
+  const tracker = events.configured()
+  tracker.track('view', {
+    category: 'login',
+    action: 'scan',
+  })
 
   const handleCode = e => {
     const url = new URL(e.detail.url)

--- a/src/pages/Rewards.svelte
+++ b/src/pages/Rewards.svelte
@@ -1,5 +1,6 @@
 <script>
   import page from 'page'
+  import events from '../services/events'
   import { ButtonLink } from '../components'
   import prizeStore from '../store/prizes'
   import playerStore from '../store/player'
@@ -8,6 +9,11 @@
   let loading = true
 
   const openPrizeAtIndex = index => page(`/rewards/${index}`)
+
+  const tracker = events.configured()
+  tracker.track('view', {
+    category: 'rewards',
+  })
 
   $: {
     if ($prizeStore.data && $playerStore.data) {

--- a/src/pages/ScanContact.svelte
+++ b/src/pages/ScanContact.svelte
@@ -1,8 +1,12 @@
 <script>
   import page from 'page'
+  import events from '../services/events'
   import { QRScanner } from '../components'
 
+  const tracker = events.configured()
+
   const handleCode = e => {
+    tracker.track('scan')
     const url = new URL(e.detail.url)
     page.redirect(url.pathname)
   }

--- a/src/pages/VerifyAccount/index.svelte
+++ b/src/pages/VerifyAccount/index.svelte
@@ -3,11 +3,18 @@
   import PageWithAction from '../../layout/PageWithAction'
   import { AvatarEditor, Button, Attributes } from '../../components'
   import cosmos from '../../services/cosmos'
+  import events from '../../services/events'
   import s3 from '../../services/s3'
   import processUrl from './process-url'
 
   let loading = false
   let avatarFile
+
+  const tracker = events.configured()
+  tracker.track('view', {
+    category: 'onboarding',
+    label: 'verify',
+  })
 
   const { address, secret, avatarUploadUrl, profile } = processUrl()
 
@@ -19,6 +26,10 @@
     await cosmos.claimBadge(address, secret, profile)
     loading = false
     page('/')
+    tracker.track('click', {
+      category: 'onboarding',
+      label: 'verify',
+    })
   }
 </script>
 

--- a/src/pages/ViewContact.svelte
+++ b/src/pages/ViewContact.svelte
@@ -1,6 +1,12 @@
 <script>
   import cosmos from '../services/cosmos'
+  import events from '../services/events'
   import { Avatar, TextInput } from '../components'
+
+  const tracker = events.configured()
+  tracker.track('view', {
+    category: 'connection',
+  })
 
   export let pageParams
   const scanPromise = cosmos.getScan(pageParams.scanId, true)

--- a/src/services/events.js
+++ b/src/services/events.js
@@ -1,0 +1,101 @@
+/* eslint-disable */
+
+import config from '../config'
+
+export default {
+  configured() {
+    if (window.analytics && window.analytics.invoked) {
+      return window.analytics
+    } else {
+      return this.configure()
+    }
+  },
+  configure() {
+    // Create a queue, but don't obliterate an existing one!
+    var analytics = (window.analytics = window.analytics || [])
+
+    // If the real analytics.js is already on the page return.
+    if (analytics.initialize) return
+
+    // If the snippet was invoked already show an error.
+    if (analytics.invoked) {
+      if (window.console && console.error) {
+        console.error('Segment snippet included twice.')
+      }
+      return
+    }
+
+    // Invoked flag, to make sure the snippet
+    // is never invoked twice.
+    analytics.invoked = true
+
+    // A list of the methods in Analytics.js to stub.
+    analytics.methods = [
+      'trackSubmit',
+      'trackClick',
+      'trackLink',
+      'trackForm',
+      'pageview',
+      'identify',
+      'reset',
+      'group',
+      'track',
+      'ready',
+      'alias',
+      'debug',
+      'page',
+      'once',
+      'off',
+      'on',
+    ]
+
+    // Define a factory to create stubs. These are placeholders
+    // for methods in Analytics.js so that you never have to wait
+    // for it to load to actually record data. The `method` is
+    // stored as the first argument, so we can replay the data.
+    analytics.factory = function(method) {
+      return function() {
+        var args = Array.prototype.slice.call(arguments)
+        args.unshift(method)
+        analytics.push(args)
+        return analytics
+      }
+    }
+
+    // For each of our methods, generate a queueing stub.
+    for (var i = 0; i < analytics.methods.length; i++) {
+      var key = analytics.methods[i]
+      analytics[key] = analytics.factory(key)
+    }
+
+    // Define a method to load Analytics.js from our CDN,
+    // and that will be sure to only ever load it once.
+    analytics.load = function(key, options) {
+      // Create an async script element based on your key.
+      var script = document.createElement('script')
+      script.type = 'text/javascript'
+      script.async = true
+      script.src =
+        'https://cdn.segment.com/analytics.js/v1/' + key + '/analytics.min.js'
+
+      // Insert our script next to the first script element.
+      var first = document.getElementsByTagName('script')[0]
+      first.parentNode.insertBefore(script, first)
+      analytics._loadOptions = options
+    }
+
+    // Add a version to keep track of what's in the wild.
+    analytics.SNIPPET_VERSION = '4.1.0'
+
+    // Load Analytics.js with your key, which will automatically
+    // load the tools you've enabled for your account. Boosh!
+    analytics.load(config.segmentWriteApiKey)
+
+    // Make the first page call to load the integrations. If
+    // you'd like to manually name or tag the page, edit or
+    // move this call however you'd like.
+    analytics.page()
+
+    return analytics
+  },
+}


### PR DESCRIPTION
No events implemented for reward claims, we have general page tracking for all pages visited, and explicit events fired for certain pages. 