### PR TITLE
Boost notification change

### DIFF
--- a/src/pages/Home/index.svelte
+++ b/src/pages/Home/index.svelte
@@ -69,7 +69,7 @@
       <div class="boost">
         <header>Boost Active</header>
         <p>
-          Scanning select sponsers will earn you {bonusPercent}% bonus
+          Scanning sponsers will earn you {bonusPercent}% bonus
           reputation points
         </p>
       </div>


### PR DESCRIPTION
We removed the ability to offer different boosts by sponsor so I changed "select sponsors" was changed to "sponsors".